### PR TITLE
change expected deployed application ID

### DIFF
--- a/application-packages/WorkflowS2Probav/DeployProcess_WorkflowS2Probav.json
+++ b/application-packages/WorkflowS2Probav/DeployProcess_WorkflowS2Probav.json
@@ -80,21 +80,21 @@
 			},
 			"steps": {
 				"stacker_s2": {
-					"run": "StackerFromCRIM.cwl",
+					"run": "Stacker.cwl",
 					"in": {
 						"files": "image-s2"
 					},
 					"out": ["output"]
 				},
 				"stacker_probav": {
-					"run": "StackerFromCRIM.cwl",
+					"run": "Stacker.cwl",
 					"in": {
 						"files": "image-probav"
 					},
 					"out": ["output"]
 				},
 				"stack_creation": {
-					"run": "StackerFromCRIM.cwl",
+					"run": "Stacker.cwl",
 					"in": {
 						"files": ["stacker_s2/output",
 						"stacker_probav/output"]
@@ -102,7 +102,7 @@
 					"out": ["output"]
 				},
 				"sfs": {
-					"run": "SFSFromCRIM.cwl",
+					"run": "SFS.cwl",
 					"in": {
 						"source_product": "stack_creation/output"
 					},


### PR DESCRIPTION
demo/test workflow execution prepares "Stacker" and "SFS" which cannot be found when referred to "StackerFromCRIM" and "SFSFromCRIM". This rename *should* (to be validated when merged) fix test `test_demo_workflow_S2_and_ProbaV `.